### PR TITLE
Issue 66 Update package-lock / npm to stop continous changes to package-lock

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -32,5 +32,8 @@
   },
   "pre-commit": [
     "lint"
-  ]
+  ],
+  "engines": {
+    "npm": ">=6.6"
+  }
 }


### PR DESCRIPTION
Issue #66 
Avoid package-lock ping-pong.

Changes:
See https://github.com/c-hive/guides/blob/master/js/best-practices.md#specify-npm-version-requirements-to-avoid-package-lock-ping-pong