### PR TITLE
Issue 95 Fix light-dark background

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -33,7 +33,7 @@ export default class MyDocument extends Document {
           <link rel="shortcut icon" type="image/x-icon" href="./favicon.ico" />
         </Head>
         {/* We need to use explicit styles here, because of the initial render */}
-        <body style={{background: themes.dark.background}}>
+        <body style={{background: themes.dark.loadingScreenBackground}}>
           <Main />
           <NextScript />
         </body>

--- a/src/resources/Themes/Themes.js
+++ b/src/resources/Themes/Themes.js
@@ -1,4 +1,5 @@
 export const dark = {
+  loadingScreenBackground: "#3F3F3F",
   background: "#3F3F3F !important",
   color: "#DBDBDB !important",
   cardBackground: "rgb(75, 75, 75)",


### PR DESCRIPTION
 Issue #95      
Fix the messed up background change between the themes.

Changes:
- [x] avoid using inline !important in the loading screen

Preview:
![Peek 2020-03-18 21-32](https://user-images.githubusercontent.com/18705136/77004803-0501c380-6960-11ea-9637-9c1bea1c6754.gif)
