### PR TITLE
Fix <title> tag usage

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,4 +1,3 @@
-// pages/_app.js
 import App from "next/app";
 import Head from "next/head";
 import React from "react";

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,0 +1,30 @@
+// pages/_app.js
+import App from "next/app";
+import Head from "next/head";
+import React from "react";
+import config from "../config/config.example.yml";
+
+export default class MyApp extends App {
+  static async getInitialProps({ Component, ctx }) {
+    let pageProps = {};
+
+    if (Component.getInitialProps) {
+      pageProps = await Component.getInitialProps(ctx);
+    }
+
+    return { pageProps };
+  }
+
+  render() {
+    const { Component, pageProps } = this.props;
+
+    return (
+      <>
+        <Head>
+          <title>{config.name}</title>
+        </Head>
+        <Component {...pageProps} />
+      </>
+    );
+  }
+}

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -2,7 +2,6 @@ import React from "react";
 import Document, { Html, Head, Main, NextScript } from "next/document";
 import { ServerStyleSheet } from "styled-components";
 import { dark as darkTheme } from "../src/resources/Themes/Themes";
-import config from "../config/config.example.yml";
 
 export default class MyDocument extends Document {
   static async getInitialProps(ctx) {
@@ -34,7 +33,6 @@ export default class MyDocument extends Document {
     return (
       <Html>
         <Head>
-          <title>{config.name}</title>
           <link rel="shortcut icon" type="image/x-icon" href="./favicon.ico" />
         </Head>
         {/* We need to use explicit styles here, because of the initial render */}


### PR DESCRIPTION
The following error bubbles up in the console:

> Warning: <title> should not be used in _document.js's <Head>. https://err.sh/next.js/no-document-title

Also see: https://github.com/zeit/next.js/issues/4596