### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           path: node_modules
           key: ${{ runner.OS }}-js-dependencies-${{ hashFiles('**/package-lock.json') }}
-          restore-key: |
+          restore-keys: |
             ${{ runner.OS }}-js-dependencies-
       - name: Install JS dependencies
         run: npm install

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           path: node_modules
           key: ${{ runner.OS }}-js-dependencies-${{ hashFiles('**/package-lock.json') }}
-          restore-key: |
+          restore-keys: |
             ${{ runner.OS }}-js-dependencies-
       - name: Install JS dependencies
         run: npm install


### PR DESCRIPTION
https://github.com/c-hive/dotdev/actions/runs/108991493

By following the [official examples](https://github.com/actions/cache/blob/master/examples.md#macos-and-ubuntu) it's supposed to be `restore-keys` (in plural form). It's weird, though, because the `CI` workflow doesn't fail whatsoever: https://github.com/c-hive/dotdev/actions/runs/108996802.